### PR TITLE
Call prepare after setting source

### DIFF
--- a/library/src/main/java/com/yqritc/scalablevideoview/ScalableVideoView.java
+++ b/library/src/main/java/com/yqritc/scalablevideoview/ScalableVideoView.java
@@ -135,28 +135,33 @@ public class ScalableVideoView extends TextureView implements TextureView.Surfac
     public void setDataSource(@NonNull String path) throws IOException {
         initializeMediaPlayer();
         mMediaPlayer.setDataSource(path);
+        this.prepare();
     }
 
     public void setDataSource(@NonNull Context context, @NonNull Uri uri,
             @Nullable Map<String, String> headers) throws IOException {
         initializeMediaPlayer();
         mMediaPlayer.setDataSource(context, uri, headers);
+        this.prepare();
     }
 
     public void setDataSource(@NonNull Context context, @NonNull Uri uri) throws IOException {
         initializeMediaPlayer();
         mMediaPlayer.setDataSource(context, uri);
+        this.prepare();
     }
 
     public void setDataSource(@NonNull FileDescriptor fd, long offset, long length)
             throws IOException {
         initializeMediaPlayer();
         mMediaPlayer.setDataSource(fd, offset, length);
+        this.prepare();
     }
 
     public void setDataSource(@NonNull FileDescriptor fd) throws IOException {
         initializeMediaPlayer();
         mMediaPlayer.setDataSource(fd);
+        this.prepare();
     }
 
     public void setScalableType(ScalableType scalableType) {


### PR DESCRIPTION
By default the mediaplayer's prepare method is not called. You have to call it before you can play video.
